### PR TITLE
Feature/parser

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -38,13 +38,14 @@ def upload():
     pdf_path = os.path.join(UPLOAD_FOLDER, f"{job_id}.pdf")
     file.save(pdf_path)
 
-    jobs[job_id] = {"status": "parsing", "result": None, "error": None}
+    jobs[job_id] = {"status": "parsing", "result": None, "error": None, "parsed_pages": None}
 
     # we should migrate to celery and redis (see if time permits)
     try:
         # Step 1: Parse PDF
         jobs[job_id]["status"] = "parsing"
         pages = parse_pdf(pdf_path)
+        jobs[job_id]["parsed_pages"] = pages
 
         # Step 2: Build vectorstore
         jobs[job_id]["status"] = "indexing"
@@ -73,6 +74,21 @@ def status(job_id):
     if not job:
         return jsonify({"error": "Job not found"}), 404
     return jsonify(job), 200
+
+@app.route("/parsed/<job_id>", methods=["GET"])
+def parsed(job_id):
+    """
+    Get the parsed content for a specific job.
+    """
+    job = jobs.get(job_id)
+    if not job:
+        return jsonify({"error": "Job not found"}), 404
+
+    # Return the parsed content (if available)
+    if job.get("parsed_pages") is None:
+        return jsonify({"error": "Parsing not done yet"}), 202
+
+    return jsonify({"parsed_pages": job["parsed_pages"]}), 200
 
 if __name__ == "__main__":
     app.run(debug=True, port=5000)

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -1,2 +1,104 @@
-def parse_pdf(pdf_path):
-    raise NotImplementedError("PDF parsing not implemented yet")
+"""
+parser.py
+---------
+Extracts text and tables from a PDF contract using pdfplumber.
+Returns a list of page dicts: { page_num, text, tables }
+
+"""
+
+from typing import List, Dict, Any
+import pdfplumber
+
+
+
+def parse_pdf(pdf_path: str) -> List[Dict[str, Any]]:
+    """
+    Parse a PDF and return structured page data.
+
+    Returns:
+        List of dicts:
+        [
+            {
+                "page_num": 1,          # 1-indexed
+                "text": "...",          # cleaned plain text
+                "tables": [             # list of tables found on this page
+                    [["col1", "col2"], ["val1", "val2"], ...],
+                    ...
+                ]
+            },
+            ...
+        ]
+    """
+    pages = []
+
+    with pdfplumber.open(pdf_path) as pdf:
+        for i, page in enumerate(pdf.pages):
+            page_num = i + 1
+
+            # --- Extract plain text ---
+            raw_text = page.extract_text(x_tolerance=3, y_tolerance=3) or ""
+            text = _clean_text(raw_text)
+
+            # --- Extract tables ---
+            tables = []
+            try:
+                extracted = page.extract_tables()
+                if extracted:
+                    for table in extracted:
+                        # Filter out fully-None rows
+                        clean_table = [
+                            [cell or "" for cell in row]
+                            for row in table
+                            if any(cell for cell in row)
+                        ]
+                        if clean_table:
+                            tables.append(clean_table)
+            except Exception:
+                pass  # Table extraction failing is non-fatal
+
+            pages.append({
+                "page_num": page_num,
+                "text": text,
+                "tables": tables,
+            })
+
+    return pages
+
+
+def _clean_text(text: str) -> str:
+    """
+    Normalize whitespace and remove common PDF extraction artifacts.
+    """
+    if not text:
+        return ""
+
+    lines = text.splitlines()
+    cleaned = []
+    for line in lines:
+        line = line.strip()
+        # Drop lines that are just page numbers or single characters
+        if len(line) <= 2:
+            continue
+        # Collapse multiple spaces within a line
+        line = " ".join(line.split())
+        cleaned.append(line)
+
+    return "\n".join(cleaned)
+
+
+
+
+def pages_to_full_text(pages: List[Dict[str, Any]]) -> str:
+    """
+    Flatten all pages into a single string, including table content.
+    """
+    parts = []
+    for p in pages:
+        parts.append(f"--- Page {p['page_num']} ---")
+        parts.append(p["text"])
+        for table in p.get("tables", []):
+            parts.append("[TABLE]")
+            for row in table:
+                parts.append(" | ".join(row))
+            parts.append("[/TABLE]")
+    return "\n".join(parts)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,8 +39,11 @@ document.getElementById("uploadForm").addEventListener("submit", async function(
     const data = await response.json();
 
     if (response.ok) {
-        document.getElementById("status").innerText =
-            "Job started! Job ID: " + data.job_id;
+        const statusEl = document.getElementById("status");
+        statusEl.innerHTML =
+            `Job started! <a href="/status/${data.job_id}">
+                View status (Job ID: ${data.job_id})
+            </a>`;
     } else {
         document.getElementById("status").innerText =
             "Error: " + data.error;


### PR DESCRIPTION
This PR enhances the Flask backend to parse uploaded PDFs and expose a new endpoint to retrieve the parsed content. Previously, the backend only accepted PDF uploads and tracked job status.

Changes:

- Parse uploaded PDFs using parse_pdf after /upload.
- Store parsed PDF text temporarily in the job object under parsed_pages.
- Add GET /parsed/<job_id> endpoint to return parsed content as JSON.

---
Resolve #3