### PR TITLE
Add compliance analysis module with LLM

### DIFF
--- a/backend/analyzer.py
+++ b/backend/analyzer.py
@@ -1,2 +1,166 @@
-def analyze_compliance(job_id):
-    raise NotImplementedError("Compliance analysis not implemented yet")
+"""
+analyzer.py
+-----------
+Runs compliance analysis for all 5 questions against a job's vectorstore.
+
+Flow per question:
+1. Retrieve top-k relevant chunks using the question's retrieval_query
+2. Build prompt with requirement + chunks
+3. Call Ollama (llama3)
+4. Parse JSON response and validate with Pydantic
+5. Retry once with a stricter prompt if parsing fails
+
+Returns a serializable dict conforming to ComplianceReport schema.
+"""
+
+import json
+import re
+import logging
+from typing import Any, Dict
+
+from langchain_ollama import OllamaLLM
+
+from vectorstore import get_vectorstore
+from schemas import ComplianceResult, ComplianceReport
+from prompts import COMPLIANCE_QUESTIONS, ANALYSIS_PROMPT_TEMPLATE
+
+logger = logging.getLogger(__name__)
+
+OLLAMA_MODEL = "llama3"
+TOP_K_CHUNKS = 6  # Chunks to retrieve per question
+
+# Retry prompt — more explicit when the model returns bad JSON
+RETRY_PROMPT_SUFFIX = """
+IMPORTANT: Your previous response was not valid JSON. 
+Respond with ONLY a raw JSON object. 
+Start your response with {{ and end with }}.
+Do not include any text before or after the JSON.
+"""
+
+
+def analyze_compliance(job_id: str) -> Dict[str, Any]:
+    """
+    Run compliance analysis for all questions for the given job_id.
+
+    Returns:
+        Serializable dict matching ComplianceReport schema.
+    """
+    vs = get_vectorstore(job_id)
+    llm = OllamaLLM(model=OLLAMA_MODEL, temperature=0)
+
+    results = []
+    for question in COMPLIANCE_QUESTIONS:
+        logger.info(f"Analyzing question {question['id']}: {question['title']}")
+        result = _analyze_single_question(llm, vs, question, job_id)
+        results.append(result)
+
+    report = ComplianceReport(job_id=job_id, results=results)
+    return report.to_dict()
+
+
+def _analyze_single_question(
+    llm: OllamaLLM,
+    vs,
+    question: Dict[str, Any],
+    job_id: str,
+) -> ComplianceResult:
+    """
+    Analyze one compliance question. Retries once on JSON parse failure.
+    On second failure, returns a safe fallback result.
+    """
+    # Retrieve relevant chunks
+    docs = vs.similarity_search(question["retrieval_query"], k=TOP_K_CHUNKS)
+    context = _format_context(docs)
+
+    prompt = ANALYSIS_PROMPT_TEMPLATE.format(
+        requirement=question["requirement"],
+        context=context,
+    )
+
+    # First attempt
+    raw = llm.invoke(prompt)
+    parsed = _try_parse_response(raw)
+
+    # Retry on failure
+    if parsed is None:
+        logger.warning(f"Q{question['id']}: JSON parse failed, retrying...")
+        retry_prompt = prompt + RETRY_PROMPT_SUFFIX
+        raw = llm.invoke(retry_prompt)
+        parsed = _try_parse_response(raw)
+
+    # Fallback if retry also fails
+    if parsed is None:
+        logger.error(f"Q{question['id']}: Both attempts failed. Using fallback.")
+        return ComplianceResult(
+            question_id=question["id"],
+            question_title=question["title"],
+            compliance_state="Non-Compliant",
+            confidence=0,
+            relevant_quotes=[],
+            rationale="Analysis failed: could not parse model response. Manual review required.",
+        )
+
+    # Validate with Pydantic
+    try:
+        return ComplianceResult(
+            question_id=question["id"],
+            question_title=question["title"],
+            compliance_state=parsed.get("compliance_state", "Non-Compliant"),
+            confidence=int(parsed.get("confidence", 50)),
+            relevant_quotes=parsed.get("relevant_quotes", []),
+            rationale=parsed.get("rationale", ""),
+        )
+    except Exception as e:
+        logger.error(f"Q{question['id']}: Pydantic validation failed: {e}")
+        return ComplianceResult(
+            question_id=question["id"],
+            question_title=question["title"],
+            compliance_state="Non-Compliant",
+            confidence=0,
+            relevant_quotes=[],
+            rationale=f"Validation error: {str(e)}. Manual review required.",
+        )
+
+
+def _try_parse_response(raw: str) -> Dict[str, Any] | None:
+    """
+    Attempt to parse the LLM's response as JSON.
+    Handles common issues:
+    - Markdown code fences (```json ... ```)
+    - Leading/trailing prose before/after the JSON object
+    """
+    if not raw:
+        return None
+
+    # Strip markdown fences
+    text = re.sub(r"```(?:json)?", "", raw).replace("```", "").strip()
+
+    # Try direct parse
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Try to extract just the JSON object via regex
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group())
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+def _format_context(docs) -> str:
+    """
+    Format retrieved documents into a readable context block for the prompt.
+    Includes page number metadata so the model can reference sections.
+    """
+    parts = []
+    for i, doc in enumerate(docs, 1):
+        page = doc.metadata.get("page", "?")
+        doc_type = doc.metadata.get("type", "text")
+        label = f"Excerpt {i} (Page {page}, {doc_type})"
+        parts.append(f"[{label}]\n{doc.page_content.strip()}")
+    return "\n\n".join(parts)

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -1,0 +1,115 @@
+"""
+prompts.py
+----------
+Compliance question definitions and prompt templates.
+
+Each question has:
+- id: int
+- title: short display name
+- requirement: the full compliance requirement text from the assignment
+- retrieval_query: what to search for in the vectorstore (can differ from the
+  requirement text — tuned to find the most relevant contract clauses)
+"""
+
+COMPLIANCE_QUESTIONS = [
+    {
+        "id": 1,
+        "title": "Password Management",
+        "requirement": (
+            "The contract must require a documented password standard covering: "
+            "password length/strength, prohibition of default and known-compromised passwords, "
+            "secure storage (no plaintext; salted hashing if stored), brute-force protections "
+            "(lockout/rate limiting), prohibition on password sharing, vaulting of privileged "
+            "credentials/recovery codes, and time-based rotation for break-glass credentials."
+        ),
+        "retrieval_query": (
+            "password policy length strength complexity default credentials storage "
+            "hashing brute force lockout rotation privileged vault"
+        ),
+    },
+    {
+        "id": 2,
+        "title": "IT Asset Management",
+        "requirement": (
+            "The contract must require an in-scope asset inventory (including cloud accounts/"
+            "subscriptions, workloads, databases, security tooling), define minimum inventory "
+            "fields, require at least quarterly reconciliation/review, and require secure "
+            "configuration baselines with drift remediation and prohibition of insecure defaults."
+        ),
+        "retrieval_query": (
+            "asset inventory cloud accounts workloads databases configuration baseline "
+            "reconciliation quarterly drift remediation insecure defaults"
+        ),
+    },
+    {
+        "id": 3,
+        "title": "Security Training & Background Checks",
+        "requirement": (
+            "The contract must require security awareness training on hire and at least annually, "
+            "and background screening for personnel with access to Company Data to the extent "
+            "permitted by law, including maintaining a screening policy and attestation/evidence."
+        ),
+        "retrieval_query": (
+            "security awareness training annual background check screening personnel "
+            "employees access company data attestation policy"
+        ),
+    },
+    {
+        "id": 4,
+        "title": "Data in Transit Encryption",
+        "requirement": (
+            "The contract must require encryption of Company Data in transit using TLS 1.2+ "
+            "(preferably TLS 1.3 where feasible) for Company-to-Service traffic, administrative "
+            "access pathways, and applicable Service-to-Subprocessor transfers, with certificate "
+            "management and avoidance of insecure cipher suites."
+        ),
+        "retrieval_query": (
+            "encryption in transit TLS 1.2 1.3 data transfer HTTPS cipher suite "
+            "certificate subprocessor administrative access"
+        ),
+    },
+    {
+        "id": 5,
+        "title": "Network Authentication & Authorization Protocols",
+        "requirement": (
+            "The contract must specify authentication mechanisms (e.g., SAML SSO for users, "
+            "OAuth/token-based for APIs), require MFA for privileged/production access, require "
+            "secure admin pathways (bastion/secure gateway) with session logging, and require "
+            "RBAC authorization."
+        ),
+        "retrieval_query": (
+            "authentication MFA multi-factor SAML SSO OAuth RBAC role-based access control "
+            "privileged production admin bastion session logging authorization"
+        ),
+    },
+]
+
+
+ANALYSIS_PROMPT_TEMPLATE = """You are a strict compliance analyst reviewing a third-party contract.
+
+Your task: assess whether the contract satisfies the compliance requirement below.
+
+=== COMPLIANCE REQUIREMENT ===
+{requirement}
+
+=== RELEVANT CONTRACT EXCERPTS ===
+{context}
+
+=== INSTRUCTIONS ===
+1. Read the excerpts carefully and decide on the compliance state:
+   - "Fully Compliant": all aspects of the requirement are explicitly addressed.
+   - "Partially Compliant": some aspects are addressed but others are missing or unclear.
+   - "Non-Compliant": the requirement is not addressed or contradicted.
+2. Extract direct quotes from the excerpts that are most relevant. Use the exact wording from the excerpts.
+3. Write a concise rationale explaining your assessment.
+4. Estimate your confidence as an integer 0-100.
+
+Respond ONLY with a valid JSON object. No markdown, no explanation outside the JSON.
+
+{{
+  "compliance_state": "Fully Compliant" | "Partially Compliant" | "Non-Compliant",
+  "confidence": <integer 0-100>,
+  "relevant_quotes": ["<exact quote from excerpts>", ...],
+  "rationale": "<your reasoning>"
+}}
+"""

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,51 @@
+"""
+schemas.py
+----------
+Pydantic models for validating and serializing the compliance analysis output.
+"""
+
+from typing import List, Literal
+from pydantic import BaseModel, Field, field_validator
+
+
+ComplianceState = Literal["Fully Compliant", "Partially Compliant", "Non-Compliant"]
+
+
+class ComplianceResult(BaseModel):
+    question_id: int = Field(..., description="Compliance question number (1-5)")
+    question_title: str = Field(..., description="Short title of the compliance area")
+    compliance_state: ComplianceState
+    confidence: int = Field(..., ge=0, le=100, description="Confidence score 0-100")
+    relevant_quotes: List[str] = Field(default_factory=list)
+    rationale: str
+
+    @field_validator("compliance_state", mode="before")
+    @classmethod
+    def normalize_state(cls, v: str) -> str:
+        """
+        Be lenient with LLM output — normalize common variants before
+        strict validation kicks in.
+        """
+        if not isinstance(v, str):
+            raise ValueError("compliance_state must be a string")
+        v = v.strip()
+        mapping = {
+            "fully compliant": "Fully Compliant",
+            "fully_compliant": "Fully Compliant",
+            "partial": "Partially Compliant",
+            "partially compliant": "Partially Compliant",
+            "partially_compliant": "Partially Compliant",
+            "non-compliant": "Non-Compliant",
+            "non_compliant": "Non-Compliant",
+            "noncompliant": "Non-Compliant",
+            "not compliant": "Non-Compliant",
+        }
+        return mapping.get(v.lower(), v)
+
+
+class ComplianceReport(BaseModel):
+    job_id: str
+    results: List[ComplianceResult]
+
+    def to_dict(self):
+        return self.model_dump()


### PR DESCRIPTION
This PR introduces the analyzer.py module to perform compliance analysis on uploaded PDFs. The module retrieves relevant chunks from a job’s vectorstore and evaluates them against all 5 compliance questions using the Ollama llama3 LLM.

Key Features:
- Retrieve top-k chunks per question from the vectorstore.
- Build prompts combining compliance requirements and contextual chunks.
- Invoke LLM and parse JSON responses robustly, including retries on parsing failure.
- Validate LLM output with Pydantic models (ComplianceResult and ComplianceReport).

---
Resolve #7 
